### PR TITLE
fix(nextauth): Implement exact NextAuth configuration to resolve 400 Bad Request

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,45 @@
+import NextAuth from 'next-auth'
+import CredentialsProvider from 'next-auth/providers/credentials'
 
-import NextAuth from "next-auth";
-import { authOptions } from "@/lib/auth-options";
+const handler = NextAuth({
+  secret: process.env.NEXTAUTH_SECRET,
+  providers: [
+    CredentialsProvider({
+      name: 'credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        if (credentials?.email === process.env.ADMIN_EMAIL && 
+            credentials?.password === process.env.ADMIN_PASSWORD) {
+          return {
+            id: '1',
+            email: credentials.email,
+            name: 'Admin'
+          }
+        }
+        return null
+      }
+    })
+  ],
+  pages: {
+    signIn: '/admin/login'
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = user.id
+      }
+      return token
+    },
+    async session({ session, token }) {
+      if (token) {
+        session.user.id = token.id as string
+      }
+      return session
+    }
+  }
+})
 
-const handler = NextAuth(authOptions);
-
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,23 @@
-import { NextResponse } from 'next/server'
-import type { NextRequest } from 'next/server'
+import { withAuth } from 'next-auth/middleware'
 
-export const config = { matcher: ['/admin/:path*'] }
+export default withAuth(
+  function middleware(req) {
+    // Middleware logic here if needed
+  },
+  {
+    callbacks: {
+      authorized: ({ token, req }) => {
+        // Allow /admin/health without authentication
+        if (req.nextUrl.pathname.startsWith('/admin/health')) {
+          return true
+        }
+        // Require authentication for all other /admin routes
+        return !!token
+      }
+    }
+  }
+)
 
-export default function middleware(req: NextRequest) {
-  const url = new URL(req.url)
-  if (url.pathname.startsWith('/admin/health')) return NextResponse.next()
-
-  const hasAuthEnv = !!process.env.NEXTAUTH_URL && !!process.env.NEXTAUTH_SECRET
-  if (!hasAuthEnv) return NextResponse.next()
-
-  const hasSession = req.cookies.get('next-auth.session-token') || req.cookies.get('__Secure-next-auth.session-token')
-  if (!hasSession) { url.pathname = '/admin/login'; return NextResponse.redirect(url) }
-
-  return NextResponse.next()
+export const config = {
+  matcher: ['/admin/:path*']
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
+  trailingSlash: false,
   experimental: {
     appDir: true,
   },


### PR DESCRIPTION
## 🔧 Correção NextAuth - Implementação Exata

### Problema Resolvido
- Erro 400 Bad Request nas rotas /admin
- Configuração NextAuth incompleta/incorreta

### Alterações Implementadas

#### 1. **app/api/auth/[...nextauth]/route.ts**
- ✅ Implementação exata do Credentials provider
- ✅ `secret: process.env.NEXTAUTH_SECRET` obrigatório
- ✅ Validação com ADMIN_EMAIL e ADMIN_PASSWORD
- ✅ Configuração de páginas customizadas (`signIn: '/admin/login'`)
- ✅ Callbacks JWT e session configurados

#### 2. **middleware.ts**
- ✅ Uso do `withAuth` do next-auth/middleware
- ✅ Proteção de `/admin/*` mas liberação de `/admin/health`
- ✅ Callback `authorized` com lógica de token

#### 3. **next.config.js**
- ✅ `output: 'standalone'` para Render
- ✅ `trailingSlash: false`
- ✅ Mantidas configurações existentes

### Próximos Passos
1. **Merge deste PR**
2. **Configurar Environment Variables no Render:**
   - `NEXTAUTH_URL=https://www.paranhospr.com.br`
   - `NEXTAUTH_SECRET=Q1Z2c0h1S3V2Y3pDa0E2dU5oVG1oZUR6YUNYQ0VxR1Q=`
   - `ADMIN_EMAIL=admin@paranhospr.com.br`
   - `ADMIN_PASSWORD=admin123`
   - `NEXT_PUBLIC_API_URL=https://paranhos-api-v2.onrender.com`
3. **Deploy no Render** (Clear build cache + Deploy latest)

### Validação Esperada
- ✅ `/` → 200
- ✅ `/admin/health?v=66` → 200  
- ✅ `/admin?v=66` → 200 ou 302 (sem 400/404)
- ✅ `/admin/dashboard?v=66` → 302 ou 200
- ✅ Login funcional com credenciais admin