### PR TITLE
fix: Corrige incompatibilidade de cookies entre NextAuth e middleware

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -8,6 +8,17 @@ export const authOptions: NextAuthOptions = {
     strategy: 'jwt',
     maxAge: 24 * 60 * 60, // 24 hours
   },
+  cookies: {
+    sessionToken: {
+      name: `next-auth.session-token`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: false // Desabilitar secure para funcionar com o middleware
+      }
+    }
+  },
   pages: { 
     signIn: '/admin/login',
     error: '/admin/login'

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,7 +23,8 @@ export async function middleware(req: NextRequest) {
     const token = await getToken({ 
       req,
       secret: process.env.NEXTAUTH_SECRET,
-      secureCookie: process.env.NODE_ENV === "production"
+      secureCookie: false, // Usar false para corresponder com a config do NextAuth
+      cookieName: "next-auth.session-token"
     })
     
     // Se não há token, redirecionar para login


### PR DESCRIPTION
## Problema Identificado

O login estava falhando devido a uma incompatibilidade entre os cookies criados pelo NextAuth e os cookies que o middleware tentava ler:

- **NextAuth** criava cookie `next-auth.session-token` (sem prefixo `__Secure-`)
- **Middleware** tentava ler com `secureCookie=true`, buscando `__Secure-next-auth.session-token`
- **Resultado**: Cookie não encontrado, redirecionamento infinito para login

## Solução Implementada

1. Configurar explicitamente cookies no NextAuth com `secure=false`
2. Ajustar middleware para usar `secureCookie=false` e `cookieName` correto
3. Garantir que ambos usem o mesmo nome: `next-auth.session-token`

## Fluxo Corrigido

1. ✅ Login cria cookie de sessão
2. ✅ Middleware consegue ler o cookie
3. ✅ Usuário acessa dashboard sem redirecionamento

## Arquivos Modificados

- `app/api/auth/[...nextauth]/route.ts`: Adicionada configuração explícita de cookies
- `middleware.ts`: Ajustado para ler o cookie correto