### PR TITLE
feat: Add debug endpoint to verify env vars in runtime

### DIFF
--- a/app/api/debug/env/route.ts
+++ b/app/api/debug/env/route.ts
@@ -1,30 +1,26 @@
-import { NextResponse } from 'next/server'
+import { NextResponse } from "next/server";
 
 export async function GET() {
-  const envCheck = {
-    NEXTAUTH_URL: {
-      exists: !!process.env.NEXTAUTH_URL,
-      value: process.env.NEXTAUTH_URL || 'NOT_SET',
-      length: process.env.NEXTAUTH_URL?.length || 0
+  const ADMIN_EMAIL = process.env.ADMIN_EMAIL ?? "";
+  const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD ?? "";
+  const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET ?? "";
+  const NEXTAUTH_URL = process.env.NEXTAUTH_URL ?? "";
+  
+  return NextResponse.json({
+    ADMIN_EMAIL: { 
+      exists: !!ADMIN_EMAIL, 
+      length: ADMIN_EMAIL.length 
     },
-    NEXTAUTH_SECRET: {
-      exists: !!process.env.NEXTAUTH_SECRET,
-      value: process.env.NEXTAUTH_SECRET ? '***HIDDEN***' : 'NOT_SET',
-      length: process.env.NEXTAUTH_SECRET?.length || 0
+    ADMIN_PASSWORD: { 
+      exists: !!ADMIN_PASSWORD, 
+      length: ADMIN_PASSWORD.length 
     },
-    ADMIN_EMAIL: {
-      exists: !!process.env.ADMIN_EMAIL,
-      value: process.env.ADMIN_EMAIL || 'NOT_SET',
-      length: process.env.ADMIN_EMAIL?.length || 0
+    NEXTAUTH_SECRET: { 
+      exists: !!NEXTAUTH_SECRET, 
+      length: NEXTAUTH_SECRET.length 
     },
-    ADMIN_PASSWORD: {
-      exists: !!process.env.ADMIN_PASSWORD,
-      value: process.env.ADMIN_PASSWORD ? '***HIDDEN***' : 'NOT_SET',
-      length: process.env.ADMIN_PASSWORD?.length || 0
+    NEXTAUTH_URL: { 
+      value: NEXTAUTH_URL 
     },
-    NODE_ENV: process.env.NODE_ENV || 'NOT_SET',
-    timestamp: new Date().toISOString()
-  }
-
-  return NextResponse.json(envCheck, { status: 200 })
+  });
 }


### PR DESCRIPTION
## Objetivo

Adicionar endpoint temporário de debug para verificar se as variáveis de ambiente estão sendo lidas corretamente em runtime no Render.

## Alterações

- Criado `app/api/debug/env/route.ts` que retorna:
  - Status de existência das ENVs críticas
  - Comprimento das strings (sem expor valores sensíveis)
  - Valor completo apenas de NEXTAUTH_URL (não sensível)

## Variáveis verificadas

- `ADMIN_EMAIL`
- `ADMIN_PASSWORD`
- `NEXTAUTH_SECRET`
- `NEXTAUTH_URL`

## Uso

```bash
curl https://www.paranhospr.com.br/api/debug/env
```

## Próximos passos

1. Fazer merge desta PR
2. Aguardar deploy no Render
3. Chamar o endpoint para verificar ENVs
4. Corrigir ENVs se necessário
5. Remover este endpoint após validação

**⚠️ Este endpoint será removido após a validação das ENVs.**