### PR TITLE
fix: Remover pages config do NextAuth para evitar conflito com middleware

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -8,10 +8,6 @@ export const authOptions: NextAuthOptions = {
     strategy: 'jwt',
     maxAge: 24 * 60 * 60, // 24 hours
   },
-  pages: { 
-    signIn: '/admin/login',
-    error: '/admin/login'
-  },
   providers: [
     Credentials({
       name: "credentials",


### PR DESCRIPTION
## 🎯 Problema Identificado
O loop de redirecionamento em `/admin/login` era causado por um **conflito entre NextAuth e middleware**:

1. NextAuth configurado com `pages: { signIn: '/admin/login' }`
2. Middleware liberando `/admin/login` como rota pública
3. NextAuth interceptando a rota e redirecionando para `/api/auth/signin`
4. Que por sua vez redirecionava de volta para `/admin/login` → **LOOP**

## 🔧 Solução
Remover a configuração `pages` do NextAuth e deixar o **middleware fazer todo o trabalho de redirecionamento**.

### Mudanças:
```diff
- pages: { 
-   signIn: '/admin/login',
-   error: '/admin/login'
- },
```

## ✅ Comportamento Esperado
- `/admin/login` → 200 (página customizada renderiza)
- `/admin/health` → 200 (health check público)
- `/admin/dashboard` (sem sessão) → 302 → `/admin/login` (middleware redireciona)
- `/admin/dashboard` (com sessão) → 200 (acesso permitido)

## 📊 Causa Raiz
NextAuth com `pages.signIn` customizado cria um interceptor que **executa antes do middleware**, causando conflito de redirecionamento.